### PR TITLE
fix(reclaim): increment ID when looping

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -270,7 +270,13 @@ func (c *Consumer) reclaim() {
 						}
 					}
 
-					start = res[len(res)-1].Id
+					newID, err := incrementMessageID(res[len(res)-1].Id)
+					if err != nil {
+						c.Errors <- err
+						break
+					}
+
+					start = newID
 				}
 			}
 		}

--- a/redis.go
+++ b/redis.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/go-redis/redis"
+	"github.com/pkg/errors"
 )
 
 var redisVersionRE = regexp.MustCompile(`redis_version:(.+)`)
@@ -46,4 +47,17 @@ func newRedisClient(options *RedisOptions) (*redis.Client, error) {
 	}
 
 	return client, nil
+}
+
+// incrementMessageID takes in a message ID (e.g. 1564886140363-0) and
+// increments the index section (e.g. 1564886140363-1). This is the next valid
+// ID value, and it can be used for paging through messages.
+func incrementMessageID(id string) (string, error) {
+	parts := strings.Split(id, "-")
+	index := parts[1]
+	parsed, err := strconv.ParseInt(index, 10, 64)
+	if err != nil {
+		return "", errors.Wrapf(err, "error parsing message ID %q", id)
+	}
+	return fmt.Sprintf("%s-%d", parts[0], parsed+1), nil
 }


### PR DESCRIPTION
because we weren't incrementing the ID before setting it to `start`, and because `XPENDING` lists messages between `start` and `end` inclusively, it never got to the point where the length of the response was 0. this resulted in an infinite loop which ate cpu and prevented graceful termination. by incrementing the id, we can now get an empty response to signal when to stop paging through.