### PR TITLE
Add ability to inject *redis.Client into producer & consumer

### DIFF
--- a/consumer_test.go
+++ b/consumer_test.go
@@ -41,15 +41,19 @@ func TestNewConsumerWithOptions(t *testing.T) {
 		assert.Equal(tt, 1*time.Second, c.options.ReclaimInterval)
 	})
 
-	t.Run("allows override of Name, GroupName, BlockingTimeout, and ReclaimTimeout", func(tt *testing.T) {
+	t.Run("allows override of Name, GroupName, BlockingTimeout, ReclaimTimeout, and RedisClient", func(tt *testing.T) {
+		rc := newRedisClient(nil)
+
 		c, err := NewConsumerWithOptions(&ConsumerOptions{
 			Name:            "test_name",
 			GroupName:       "test_group_name",
 			BlockingTimeout: 10 * time.Second,
 			ReclaimInterval: 10 * time.Second,
+			RedisClient:     rc,
 		})
 		require.NoError(tt, err)
 
+		assert.Equal(tt, rc, c.redis)
 		assert.Equal(tt, "test_name", c.options.Name)
 		assert.Equal(tt, "test_group_name", c.options.GroupName)
 		assert.Equal(tt, 10*time.Second, c.options.BlockingTimeout)

--- a/producer_test.go
+++ b/producer_test.go
@@ -24,6 +24,18 @@ func TestNewProducerWithOptions(t *testing.T) {
 		assert.NotNil(tt, p)
 	})
 
+	t.Run("allows custom *redis.Client", func(tt *testing.T) {
+		rc := newRedisClient(nil)
+
+		p, err := NewProducerWithOptions(&ProducerOptions{
+			RedisClient: rc,
+		})
+		require.NoError(tt, err)
+
+		assert.NotNil(tt, p)
+		assert.Equal(tt, rc, p.redis)
+	})
+
 	t.Run("bubbles up errors", func(tt *testing.T) {
 		_, err := NewProducerWithOptions(&ProducerOptions{
 			RedisOptions: &RedisOptions{Addr: "localhost:0"},

--- a/redis_test.go
+++ b/redis_test.go
@@ -10,24 +10,26 @@ import (
 func TestNewRedisClient(t *testing.T) {
 	t.Run("returns a new redis client", func(tt *testing.T) {
 		options := &RedisOptions{}
-		r, err := newRedisClient(options)
-		require.NoError(tt, err)
+		r := newRedisClient(options)
 
-		err = r.Ping().Err()
+		err := r.Ping().Err()
 		assert.NoError(tt, err)
 	})
 
 	t.Run("defaults options if it's nil", func(tt *testing.T) {
-		r, err := newRedisClient(nil)
-		require.NoError(tt, err)
+		r := newRedisClient(nil)
 
-		err = r.Ping().Err()
+		err := r.Ping().Err()
 		assert.NoError(tt, err)
 	})
+}
 
+func TestRedisPreflightChecks(t *testing.T) {
 	t.Run("bubbles up errors", func(tt *testing.T) {
 		options := &RedisOptions{Addr: "localhost:0"}
-		_, err := newRedisClient(options)
+		r := newRedisClient(options)
+
+		err := redisPreflightChecks(r)
 		require.Error(tt, err)
 
 		assert.Contains(tt, err.Error(), "dial tcp")


### PR DESCRIPTION
This adds a new field to both the `ProducerOptions` and `ConsumerOptions`
structs, `RedisClient`, that allows you to use dependency injection for the
Redis client instead of using options to create one internally.

This allows consumers to use the same Redis connection pool for their queue, and
any other operations they want to take elsewhere in their program. One use case
might be wanting a heartbeat operation that restarts the program if things seem
unhealthy.

Internally, this splits the function that creates and validates the Redis client
as being usable in to two functions. One to create the client, and another to
exercise the client to make sure it works and that Redis offers the features we
need.

Fixes #8