### PR TITLE
chore(makefile): update Makefile

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -31,3 +31,4 @@ issues:
     - path: _test\.go
       linters:
         - dupl
+        - scopelint


### PR DESCRIPTION
### what

- update `golangci-lint` to latest version
- disable `scopelint` for tests because it was failing with:
    ```
    consumer_test.go:120:33  scopelint  Using the variable on range scope `tt` in function literal
    ```
    which isnt a problem in our case since the `t.Run` functions block the range over `tests`
- split out installing `golangci-lint` into its own target
- fix setup command to install tools in the `./bin` directory, to work with modules, and to not rely on `realpath`