### PR TITLE
Accept a "universal" Redis client in Consumer/Producer Options

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -53,8 +53,9 @@ type ConsumerOptions struct {
 	// Concurrency dictates how many goroutines to spawn to handle the messages.
 	Concurrency int
 	// RedisClient supersedes the RedisOptions field, and allows you to inject
-	// an already-made *redis.Client for use in the consumer.
-	RedisClient *redis.Client
+	// an already-made Redis Client for use in the consumer. This may be either
+	// the standard client or a cluster client.
+	RedisClient redis.UniversalClient
 	// RedisOptions allows you to configure the underlying Redis connection.
 	// More info here:
 	// https://pkg.go.dev/github.com/go-redis/redis/v7?tab=doc#Options.
@@ -74,7 +75,7 @@ type Consumer struct {
 	Errors chan error
 
 	options   *ConsumerOptions
-	redis     *redis.Client
+	redis     redis.UniversalClient
 	consumers map[string]registeredConsumer
 	streams   []string
 	queue     chan *Message
@@ -121,7 +122,7 @@ func NewConsumerWithOptions(options *ConsumerOptions) (*Consumer, error) {
 		options.ReclaimInterval = 1 * time.Second
 	}
 
-	var r *redis.Client
+	var r redis.UniversalClient
 
 	if options.RedisClient != nil {
 		r = options.RedisClient

--- a/producer.go
+++ b/producer.go
@@ -20,8 +20,9 @@ type ProducerOptions struct {
 	// manner. More info here: https://redis.io/commands/xadd#capped-streams.
 	ApproximateMaxLength bool
 	// RedisClient supersedes the RedisOptions field, and allows you to inject
-	// an already-made *redis.Client for use in the consumer.
-	RedisClient *redis.Client
+	// an already-made Redis Client for use in the consumer. This may be either
+	// the standard client or a cluster client.
+	RedisClient redis.UniversalClient
 	// RedisOptions allows you to configure the underlying Redis connection.
 	// More info here:
 	// https://pkg.go.dev/github.com/go-redis/redis/v7?tab=doc#Options.
@@ -34,7 +35,7 @@ type ProducerOptions struct {
 // processed later by a Consumer.
 type Producer struct {
 	options *ProducerOptions
-	redis   *redis.Client
+	redis   redis.UniversalClient
 }
 
 var defaultProducerOptions = &ProducerOptions{
@@ -51,7 +52,7 @@ func NewProducer() (*Producer, error) {
 
 // NewProducerWithOptions creates a Producer using custom ProducerOptions.
 func NewProducerWithOptions(options *ProducerOptions) (*Producer, error) {
-	var r *redis.Client
+	var r redis.UniversalClient
 
 	if options.RedisClient != nil {
 		r = options.RedisClient

--- a/redis.go
+++ b/redis.go
@@ -29,7 +29,7 @@ func newRedisClient(options *RedisOptions) *redis.Client {
 // offers the functionality we need. Specifically, it also that it can connect
 // to the actual instance and that the instance supports Redis streams (i.e.
 // it's at least v5).
-func redisPreflightChecks(client *redis.Client) error {
+func redisPreflightChecks(client redis.UniversalClient) error {
 	info, err := client.Info("server").Result()
 	if err != nil {
 		return err


### PR DESCRIPTION
This allows a Redis Cluster client to be used with the package.

---

Some of our on premises users use clustered Redis; to my surprise, using a normal Redis client with a cluster is a sharp edge.

This PR allows the consumer to pass in _either_ a vanilla Redis client or a "universal" client.

Unrelated: if this requires a module version bump (not sure? existing callers _should_ work?), would you consider bumping to `go-redis/v8` at the same time?