### PR TITLE
Remove version check from Redis preflight

### DIFF
--- a/redis.go
+++ b/redis.go
@@ -30,23 +30,9 @@ func newRedisClient(options *RedisOptions) *redis.Client {
 // to the actual instance and that the instance supports Redis streams (i.e.
 // it's at least v5).
 func redisPreflightChecks(client redis.UniversalClient) error {
-	info, err := client.Info("server").Result()
+	_, err := client.Ping().Result()
 	if err != nil {
 		return err
-	}
-
-	match := redisVersionRE.FindAllStringSubmatch(info, -1)
-	if len(match) < 1 {
-		return fmt.Errorf("could not extract redis version")
-	}
-	version := strings.TrimSpace(match[0][1])
-	parts := strings.Split(version, ".")
-	major, err := strconv.Atoi(parts[0])
-	if err != nil {
-		return err
-	}
-	if major < 5 {
-		return fmt.Errorf("redis streams are not supported in version %q", version)
 	}
 
 	return nil


### PR DESCRIPTION
This commit removes the `INFO` version check from the Redis connection
preflighting.

In our automated test suite we make extensive use of
[`miniredis`](https://github.com/alicebob/miniredis) rather than
depending on a full Redis server. Miniredis is quite capable, but does
not implement the `INFO` command.

Redis 5 was released in 2018 and was a significant upgrade to Redis. I
haven't seen Redis < 5 in production since shortly after 5's
release. Therefore I believe this to be a reasonable loosening of the
constraints on redisqueue.

---

@robinjoseph08 I understand if this isn't a change you want to pull in, just thought I'd see if we could continue tracking upstream :).